### PR TITLE
big Johan refactor

### DIFF
--- a/attention_simulation.m
+++ b/attention_simulation.m
@@ -32,17 +32,20 @@ n_voxels = 2500;
 
 
 %Declare GLM for this study
-glm_var.TR = 2.5; %TR
-glm_var.blocks = 10; %no of blocks of house/face for each subrun
-glm_var.blockdur = 6; %block dur in terms of TR
-glm_var.restdur = 1; %rest dur between blocks in terms of TR
-glm_var.n_subruns = 4; %no of subruns per attention condition (TaskD+/TaskD-)
+sim_par.TR = 2.5; %TR
+sim_par.blocks = 10; %no of blocks of house/face for each subrun
+sim_par.blockdur = 6; %block dur in terms of TR
+sim_par.restdur = 1; %rest dur between blocks in terms of TR
+sim_par.n_subruns = 4; %no of subruns per attention condition (TaskD+/TaskD-)
+% For Section 4.4 results, set both to 0.5 (HP TO CONFIRM)
+sim_par.n_neurons_face_sigma = 1.45; % sigma of half-Gaussian controlling face cell frequency per voxel
+sim_par.n_neurons_house_sigma = 0.7; % same for house cell frequency
 
 % two noise sources at voxel level 
 % Physiological noise that scales with laminar bias
 physio_sigma_list = [8];
 % Dimensionality of physiological noise
-physio_vects = 20;
+physio_vects = 20; % why not 10 as in HBM sim?
 % Thermal noise that is consistent across layers
 thermal_sigma_list = [15];
 
@@ -69,17 +72,17 @@ parfor iterind=1:iter
     % Seed needs to be declared inside parfor loop otherwise matlab will seed individual workers randomly
     count = 1;
     rng(iterind * seed)
-    glm = create_glm(glm_var);
+    glm = create_glm(sim_par);
     for physio_sigma = physio_sigma_list
         for thermal_sigma = thermal_sigma_list
             for superficial_bias = superficial_bias_list
                 for attentional_modulation = attention_list
-                    params = struct('physio_sigma',physio_sigma,'physio_vects',physio_vects,'thermal_sigma',thermal_sigma,'superficial_bias',superficial_bias,'attentional_modulation',attentional_modulation);
-                    [estimates, plot_vars] = attention_simulation_iteration(n_voxels,glm_var,params,glm);
+                    iter_par = struct('physio_sigma',physio_sigma,'physio_vects',physio_vects,'thermal_sigma',thermal_sigma,'superficial_bias',superficial_bias,'attentional_modulation',attentional_modulation);
+                    [estimates, plot_vars] = attention_simulation_iteration(n_voxels,sim_par,iter_par,glm);
                     if iterind==1 && pflag            % only plot first iteration
-                        scatter_plot(params,plot_vars.dplus,plot_vars.dminus,plot_vars.deming_regression);
+                        scatter_plot(iter_par,plot_vars.dplus,plot_vars.dminus,plot_vars.deming_regression);
                     end
-                    results(iterind).params(count) = params;
+                    results(iterind).params(count) = iter_par;
                     results(iterind).estimates(count) = estimates; 
                     count = count+1;
                 end
@@ -91,279 +94,6 @@ save('att_sim_results.mat','results');
 
 end
 
-function [estimates, plot_vars] = attention_simulation_iteration(n_voxels,glm_var,params,glm)
-    
-    % let's suppose this example ROI has more face cells than house cells (let's call it FFA)
-    % Calculating this here so that each iteration can have different frequencies
-    % For Section 4.4 results, replace "n_neurons.face = abs(normrnd(0,1.1,[1, n_voxels]));" with "n_neurons.face = abs(normrnd(0,0.5,[1, n_voxels]));"
-    n_neurons.face = abs(normrnd(0,1.45,[1, n_voxels]));
-    n_neurons.house = abs(normrnd(0,0.7,[1, n_voxels]));
-    
-    
-    %======================================================================
-    % Task with distractor - TaskD+ (dplus)
-    %======================================================================
-    
-    % face stimulus, attention task, with distractor
-    attention.face = params.attentional_modulation;
-    attention.house = 1;
-    firing_rate.face = 1;
-    firing_rate.house = 1;  
-    dplus.face_response = calc_voxel_response(firing_rate, n_neurons, attention);
-
-    % house stimulus, attention task, with distractor
-    attention.face = 1;
-    attention.house = params.attentional_modulation;
-    firing_rate.face = 1;
-    firing_rate.house = 1;
-    dplus.house_response = calc_voxel_response(firing_rate, n_neurons, attention);
-    
-    % construct timecourses by scaling design matrix according to the face and house responses
-    dplus.measured_response_array = calc_measured_response(dplus,glm.design(1),params);
-    
-    
-    %detrending data
-    dplus.detrended_response_array = detrend(dplus.measured_response_array);
-    dplus.detrended_design_array = detrend(glm.design(1).design_mat);
-    dplus.detrended_SVM_array = detrend(glm.design(1).SVM_mat);
-    
-    dplus.detrended_response = horzcat(dplus.detrended_response_array{:});
-    dplus.detrended_design = horzcat(dplus.detrended_design_array{:});
-    
-    %Method 1: Z-scoring
-    dplus.zbeta_estimates = zscore(dplus.detrended_response')'/dplus.detrended_design;
-    estimates.zscore = mean(dplus.zbeta_estimates(:,1)-dplus.zbeta_estimates(:,2));
-    
-    %Method 2: SVM classifier for TaskD+
-    correct_class = 0;
-    for i=1:4
-        train_ind = setdiff(1:4,i);
-        test_ind = i;
-        train_design = blkdiag(dplus.detrended_SVM_array{train_ind});
-        test_design = dplus.detrended_SVM_array{test_ind};
-        
-        train_data = horzcat(dplus.detrended_response_array{train_ind});
-        test_data = dplus.detrended_response_array{test_ind};
-        
-        train_betas = train_data/train_design;
-        test_betas = test_data/test_design;
-        
-        test_labels = [repmat(0,1,glm_var.blocks),repmat(1,1,glm_var.blocks)]; 
-        train_labels = [test_labels,test_labels,test_labels];
-        svm_model = fitcsvm(train_betas',train_labels);
-        predict_labels = predict(svm_model,test_betas');
-        for s = 1:size(predict_labels)
-            if predict_labels(s) == test_labels(s)
-                correct_class= correct_class+1;
-            end
-        end
-    end
-    estimates.SVM = 100*correct_class/(2*glm_var.n_subruns*glm_var.blocks);
-    
-    %Method 3: LDC for TaskD+
-    LDC_dist = nan(4,1);
-    for i=1:4
-        train_ind = setdiff(1:4,i);
-        test_ind = i;
-        train_design = horzcat(dplus.detrended_design_array{train_ind});
-        test_design = dplus.detrended_design_array{test_ind};
-        train_data = horzcat(dplus.detrended_response_array{train_ind});
-        test_data = dplus.detrended_response_array{test_ind};
-        
-        train_betas = train_data/train_design;
-        train_con = train_betas *[1;-1];
-        train_predict = train_betas*train_design;
-        train_res = train_data - train_predict;
-        train_cov = covdiag(train_res');
-        train_cov = train_cov./size(train_cov,1);
-        weights = train_con' * pinv(train_cov);
-        
-        test_betas = test_data/test_design;
-        test_con = test_betas * [1;-1];
-        
-        LDC_dist(i) = test_con'*weights';
-    end
-    
-    estimates.LDC = mean(LDC_dist);
-    
-    
-    %Fitting the measured response to the GLM for the other methods
-    dplus.beta_estimates = dplus.detrended_response/dplus.detrended_design;
-    dplus.contrast_estimates = dplus.beta_estimates(:,1)-dplus.beta_estimates(:,2);
-    
-    %Store tstat for comparison with real fMRI data
-    model_fit = dplus.beta_estimates *dplus.detrended_design;
-    dplus.residual = dplus.detrended_response - model_fit;
-    dplus.std_error = std(dplus.residual,0,2)/sqrt(size(dplus.residual,2));
-    dplus.tstat = dplus.contrast_estimates./dplus.std_error;
-    estimates.tstat_dplus_mean = mean(dplus.tstat);
-    estimates.tstat_dplus_std = std(dplus.tstat);
-    
-    %Store BOLD responses for reference
-    dplus.real_bold_response = dplus.face_response'-dplus.house_response';
-    estimates.dplus_measured_response = mean(dplus.contrast_estimates);
-    
-
-    %======================================================================
-    % next, attention task without distractor - TaskD- (dminus)
-    %======================================================================
-    
-    % face stimulus, attention task, no distractor
-    attention.face = params.attentional_modulation;
-    attention.house = 1;
-    firing_rate.face = 1;
-    firing_rate.house = 0;
-    dminus.face_response = calc_voxel_response(firing_rate, n_neurons, attention);
-
-    % house stimulus, attention task, no distractor
-    attention.face = 1;
-    attention.house = params.attentional_modulation;
-    firing_rate.face = 0;
-    firing_rate.house = 1;
-    dminus.house_response = calc_voxel_response(firing_rate, n_neurons, attention);
-    
-    dminus.measured_response_array = calc_measured_response(dminus,glm.design(2),params);
-    
-    dminus.detrended_response_array = detrend(dminus.measured_response_array);
-    dminus.detrended_design_array = detrend(glm.design(2).design_mat);
-    
-    dminus.detrended_response = horzcat(dminus.detrended_response_array{:});
-    dminus.detrended_design = horzcat(dminus.detrended_design_array{:});
-    
-    
-    %Fitting the measured response to the GLM 
-    dminus.beta_estimates = dminus.detrended_response/dminus.detrended_design;
-    dminus.contrast_estimates = dminus.beta_estimates(:,1)-dminus.beta_estimates(:,2);
-    
-    %Store tstat for comparison with real fMRI data
-    model_fit = dminus.beta_estimates *dminus.detrended_design;
-    dminus.residual = dminus.detrended_response - model_fit;
-    dminus.std_error = std(dminus.residual,0,2)/sqrt(size(dminus.residual,2));
-    dminus.tstat = dminus.contrast_estimates./dminus.std_error;
-    
-    estimates.tstat_dminus_mean = mean(dminus.tstat);
-    estimates.tstat_dminus_std = std(dminus.tstat);
-
-
-    
-    
-    %======================================================================
-    % Evaluating Methods 4,5 and 6
-    %======================================================================
-    
-    % Method 4: Estimating Attention Modulation with mean(dplus/dminus)
-    raw_ratio = mean(dplus.contrast_estimates./dminus.contrast_estimates);
-    estimates.raw_ratio =  raw_ratio;
-    estimates.raw_ratio_est =  1/(1-raw_ratio);
-    
-    % Method 5: Estimating Attention Modulation with mean(dplus)/mean(dminus)
-    ROI_ratio = mean(dplus.contrast_estimates)/mean(dminus.contrast_estimates);
-    estimates.ROI_ratio =  ROI_ratio;
-    estimates.ROI_ratio_est =  1/(1-ROI_ratio);
-   
-    % Method 6: Estimating Attention Modulation with dplus/dminus Deming Regression
-    deming_regression = deming(dminus.contrast_estimates,dplus.contrast_estimates);
-    estimates.deming_regression =  deming_regression(2);
-    estimates.deming_est = 1/(1-deming_regression(2));
-    
-    
-    % Assigning variables needed for plotting 
-    plot_vars=struct('dplus',dplus,'dminus',dminus,'deming_regression',deming_regression);
-
-    
-end
-
-function voxel_response = calc_voxel_response(firing_rate, n_neurons, attention)
-    % The response of a voxel depends on two populations of cells: face cells and house cells.
-    % Each cell population can be active or not (firing_rate - 1 or 0)
-    % Each voxel varies in how many neuron cells there are of a given type (n_neurons, ie how much they contribute to the voxel)
-    % Each voxel varies in how much it is modulated by the task (attention)
-    % noise is added in a later step
-    voxel_response = firing_rate.face .* n_neurons.face .* attention.face + firing_rate.house .* n_neurons.house .* attention.house;
-end
-
-function glm = create_glm(glm_var)
-    glm.subrun_length = 2*glm_var.restdur+2*glm_var.blocks*(glm_var.blockdur+glm_var.restdur); 
-    glm.hrf_distri = spm_hrf(glm_var.TR)';
-    for j=1:2 %2 design matrices for TaskD+ and TaskD-
-        % Construct GLM matrix 
-        subrun = cell(glm_var.n_subruns,1);
-        design_mat = cell(glm_var.n_subruns,1);
-        SVM_mat = cell(glm_var.n_subruns,1);
-        for k = 1:glm_var.n_subruns   
-            %randomize order of blocks within subruns (1 is faces, 2 is houses)
-            design = zeros(2,glm.subrun_length);
-            SVM_design = zeros(2*glm_var.blocks,glm.subrun_length);
-            subrun{k} = [repmat(1,1,glm_var.blocks),repmat(2,1,glm_var.blocks)];
-            subrun{k} = subrun{k}(randperm(length(subrun{k}))); 
-            %Structure is long_rest-subrun
-            %Define start times for each subrun and input into design matrix
-            sr1_start = glm_var.restdur+1;
-
-            cur_timepoint = sr1_start;
-            for i=1:length(subrun{k})
-                design(subrun{k}(i),cur_timepoint:cur_timepoint+glm_var.blockdur-1)=1;
-                cur_timepoint = cur_timepoint+glm_var.blockdur+glm_var.restdur;
-            end
-            %convolve with HRF to generate the design matrix
-            design_mat{k}=conv2(design,glm.hrf_distri,'same');
-            
-            
-            %Generate individual columns for SVM classification
-            cur_timepoint = sr1_start;
-            c1_count = 1;
-            c2_count = 1;
-            for i=1:length(subrun{k})
-                if subrun{k}(i)==1
-                    SVM_design(c1_count,cur_timepoint:cur_timepoint+glm_var.blockdur-1)=1;
-                    c1_count = c1_count+1;
-                else
-                    SVM_design(glm_var.blocks+c2_count,cur_timepoint:cur_timepoint+glm_var.blockdur-1)=1;
-                    c2_count = c2_count+1;
-                    
-                end
-                cur_timepoint = cur_timepoint+glm_var.blockdur+glm_var.restdur;
-            end
-            %convolve with HRF to generate the design matrix
-            SVM_mat{k} = conv2(SVM_design,glm.hrf_distri,'same');
-        end
-        
-        glm.design(j).design_mat = design_mat;
-        glm.design(j).SVM_mat = SVM_mat;
-    end
-end
-
-
-function measured_response = calc_measured_response(cond,design,params)
-    measured_response = cell(size(design.design_mat,1),1);
-    noise_proj=normrnd(0,1,size(cond.face_response,2),params.physio_vects); % projection vector of physio noise vector on data
-    for i=1:size(design.design_mat,1)
-        raw_response = [cond.face_response', cond.house_response']*design.design_mat{i};
-        thermal_noise = normrnd(0,1,size(raw_response))*params.thermal_sigma;
-        noise_vect=normrnd(0,1,params.physio_vects,size(raw_response,2));   % physio noise vector that is projected across different voxels
-        physio_rnd = noise_proj*noise_vect;
-        physio_rnd = physio_rnd/sqrt(params.physio_vects/2);
-        physio_noise = physio_rnd * params.physio_sigma;
-        measured_response{i} = thermal_noise+params.superficial_bias*(raw_response+physio_noise);
-    end
-end
-
-function detrended_data = detrend(data)
-     detrended_data = cell(size(data,1),1);
-    for i=1:size(data,1)
-        % Linear, first order sinusoidal and mean detrending
-        nvols = size(data{i},2);
-        linear_trend=1:nvols;
-        sin_trend=sin((linear_trend)*2*pi/(nvols-1));
-        cos_trend=cos((linear_trend)*2*pi/(nvols-1));
-        mean_trend = ones(1,nvols);
-        dt_design = [linear_trend;sin_trend;cos_trend;mean_trend];
-
-        trend = data{i}/dt_design;
-        est = trend*dt_design;
-        detrended_data{i} = data{i} - est;
-    end
-end
 
 function scatter_plot(params,dplus,dminus,deming_regression)
     %Generate deming plots for comparison with real data
@@ -379,7 +109,7 @@ function scatter_plot(params,dplus,dminus,deming_regression)
     yFit = polyval([deming_regression(2),deming_regression(1)] , xFit);
     hold on;
     plot(xFit, yFit, 'r-')
-    ax = gca
+    ax = gca;
     ax.FontSize = 10;
     saveas(gcf,fname,'png');
     close all

--- a/attention_simulation_iteration.m
+++ b/attention_simulation_iteration.m
@@ -1,0 +1,182 @@
+function [estimates, plot_vars] = attention_simulation_iteration(n_voxels,sim_par,iter_par,glm)
+    
+    % let's suppose this example ROI has more face cells than house cells (let's call it FFA)
+    % Calculating this here so that each iteration can have different frequencies
+    n_neurons.face = abs(normrnd(0,sim_par.n_neurons_face_sigma,[1, n_voxels]));
+    n_neurons.house = abs(normrnd(0,sim_par.n_neurons_house_sigma,[1, n_voxels]));
+    
+    
+    %======================================================================
+    % Task with distractor - TaskD+ (dplus)
+    %======================================================================
+    
+    % face stimulus, attention task, with distractor
+    dplus.face_response = calc_voxel_response(struct('face', 1, 'house', 1), ...
+        n_neurons, struct('face', iter_par.attentional_modulation, 'house', 1));
+
+    % house stimulus, attention task, with distractor
+    dplus.house_response = calc_voxel_response(struct('face', 1, 'house', 1), ...
+        n_neurons, struct('face', 1, 'house', iter_par.attentional_modulation));
+    
+    % construct timecourses by scaling design matrix from dplus context (1) according to
+    % the face and house responses
+    dplus.measured_response_array = calc_measured_response(dplus,glm.design(1),iter_par);
+
+    dplus = calc_fmri_model(dplus, glm.design(1));
+    
+    %Method 1: Z-scoring
+    dplus.zbeta_estimates = zscore(dplus.detrended_response')'/dplus.detrended_design;
+    estimates.zscore = mean(dplus.zbeta_estimates(:,1)-dplus.zbeta_estimates(:,2));
+    
+    %Method 2: SVM classifier for TaskD+
+    svm_correct = {};
+    for test_ind=1:numel(dplus.detrended_SVM_array)
+        train_ind = setdiff(1:numel(dplus.detrended_SVM_array),test_ind);
+        train_design = blkdiag(dplus.detrended_SVM_array{train_ind});
+        test_design = dplus.detrended_SVM_array{test_ind};
+        
+        train_data = horzcat(dplus.detrended_response_array{train_ind});
+        test_data = dplus.detrended_response_array{test_ind};
+        
+        train_betas = train_data/train_design;
+        test_betas = test_data/test_design;
+        
+        test_labels = [zeros(1,sim_par.blocks),ones(1,sim_par.blocks)]; 
+        train_labels = repmat(test_labels, [1, numel(train_ind)]);
+        svm_model = fitcsvm(train_betas',train_labels);
+        predict_labels = predict(svm_model,test_betas');
+        svm_correct{test_ind} = predict_labels' == test_labels;
+    end
+    estimates.SVM = 100 * mean(horzcat(svm_correct{:}));
+    
+    %Method 3: LDC for TaskD+
+    LDC_dist = nan(sim_par.n_subruns,1);
+    for test_ind=1:sim_par.n_subruns
+        train_ind = setdiff(1:sim_par.n_subruns,test_ind);
+        train_design = horzcat(dplus.detrended_design_array{train_ind});
+        test_design = dplus.detrended_design_array{test_ind};
+        train_data = horzcat(dplus.detrended_response_array{train_ind});
+        test_data = dplus.detrended_response_array{test_ind};
+        
+        train_betas = train_data/train_design;
+        train_con = train_betas *[1;-1];
+        train_predict = train_betas*train_design;
+        train_res = train_data - train_predict;
+        train_cov = covdiag(train_res');
+        % what does this do?
+        train_cov = train_cov./size(train_cov,1);
+        weights = train_con' / train_cov;
+        
+        test_betas = test_data/test_design;
+        test_con = test_betas * [1;-1];
+        
+        LDC_dist(test_ind) = weights * test_con;
+    end
+    estimates.LDC = mean(LDC_dist);
+    
+    estimates.tstat_dplus_mean = mean(dplus.tstat);
+    estimates.tstat_dplus_std = std(dplus.tstat);
+    estimates.dplus_measured_response = mean(dplus.contrast_estimates);
+
+    %======================================================================
+    % next, attention task without distractor - TaskD- (dminus)
+    %======================================================================
+    
+    % face stimulus, attention task, no distractor
+    dminus.face_response = calc_voxel_response(struct('face', 1, 'house', 0), ...
+        n_neurons, struct('face', iter_par.attentional_modulation, 'house', 1));
+
+    % house stimulus, attention task, no distractor
+    dminus.house_response = calc_voxel_response(struct('face', 0, 'house', 1), ...
+        n_neurons, struct('face', 1, 'house', iter_par.attentional_modulation));
+    
+    % nb glm.design(2) is the design matrix for the dminus context (independently
+    % randomised block sequence)
+    dminus.measured_response_array = calc_measured_response(dminus,glm.design(2),iter_par);
+
+    dminus = calc_fmri_model(dminus, glm.design(2));
+    
+    estimates.tstat_dminus_mean = mean(dminus.tstat);
+    estimates.tstat_dminus_std = std(dminus.tstat);
+    
+    %======================================================================
+    % Evaluating Methods 4,5 and 6
+    %======================================================================
+    
+    % Method 4: Estimating Attention Modulation with mean(dplus/dminus)
+    estimates.raw_ratio = mean(dplus.contrast_estimates./dminus.contrast_estimates);
+    estimates.raw_ratio_est =  1/(1-estimates.raw_ratio);
+    
+    % Method 5: Estimating Attention Modulation with mean(dplus)/mean(dminus)
+    estimates.ROI_ratio = mean(dplus.contrast_estimates)/mean(dminus.contrast_estimates);
+    estimates.ROI_ratio_est =  1/(1-estimates.ROI_ratio);
+   
+    % Method 6: Estimating Attention Modulation with dplus/dminus Deming Regression
+    deming_regression = deming(dminus.contrast_estimates,dplus.contrast_estimates);
+    estimates.deming_regression =  deming_regression(2);
+    estimates.deming_est = 1/(1-estimates.deming_regression);
+    
+    % Assigning variables needed for plotting 
+    plot_vars=struct('dplus',dplus,'dminus',dminus,'deming_regression',deming_regression);
+    
+end
+
+function voxel_response = calc_voxel_response(firing_rate, n_neurons, attention)
+    % The response of a voxel depends on two populations of cells: face cells and house cells.
+    % Each cell population can be active or not (firing_rate - 1 or 0)
+    % Each voxel varies in how many neuron cells there are of a given type (n_neurons, ie how much they contribute to the voxel)
+    % Each voxel varies in how much it is modulated by the task (attention)
+    % noise is added in a later step
+    voxel_response = firing_rate.face .* n_neurons.face .* attention.face + firing_rate.house .* n_neurons.house .* attention.house;
+end
+
+function measured_response = calc_measured_response(condition,design,params)
+    measured_response = cell(size(design.design_mat,1),1);
+    noise_proj=normrnd(0,1,size(condition.face_response,2),params.physio_vects); % projection vector of physio noise vector on data
+    for i=1:size(design.design_mat,1)
+        raw_response = [condition.face_response', condition.house_response']*design.design_mat{i};
+        thermal_noise = normrnd(0,1,size(raw_response))*params.thermal_sigma;
+        noise_vect=normrnd(0,1,params.physio_vects,size(raw_response,2));   % physio noise vector that is projected across different voxels
+        physio_noise = noise_proj*noise_vect;
+        % why divide by 2?
+        physio_noise = physio_noise/sqrt(params.physio_vects/2);
+        physio_noise = physio_noise * params.physio_sigma;
+        measured_response{i} = thermal_noise+params.superficial_bias*(raw_response+physio_noise);
+    end
+end
+
+function d = calc_fmri_model(d, design)
+
+%detrending data
+d.detrended_response_array = detrend_timecourses(d.measured_response_array);
+d.detrended_design_array = detrend_timecourses(design.design_mat);
+d.detrended_SVM_array = detrend_timecourses(design.SVM_mat);
+
+d.detrended_response = horzcat(d.detrended_response_array{:});
+d.detrended_design = horzcat(d.detrended_design_array{:});
+
+%Fitting the measured response to the GLM for the other methods
+d.beta_estimates = d.detrended_response/d.detrended_design;
+d.contrast_estimates = d.beta_estimates(:,1)-d.beta_estimates(:,2);
+
+%Store tstat for comparison with real fMRI data
+model_fit = d.beta_estimates * d.detrended_design;
+d.residual = d.detrended_response - model_fit;
+d.std_error = std(d.residual,0,2)/sqrt(size(d.residual,2));
+d.tstat = d.contrast_estimates./d.std_error;
+
+% johan proposal (slightly over-general for this context)
+df = size(d.residual, 2) - rank(d.detrended_design');
+mrss = sum(d.residual.^2, 2) / df;
+cmat = inv(d.detrended_design * d.detrended_design');
+convec = [1 -1];
+se = sqrt(diag(convec * cmat * convec') * mrss);
+% about half the size of tstat_dplus_mean above
+t = d.contrast_estimates ./ se;
+% d.tstat = t;
+% / johan
+
+%Store BOLD responses for reference
+d.real_bold_response = d.face_response'-d.house_response';
+
+end

--- a/attention_simulation_iteration.m
+++ b/attention_simulation_iteration.m
@@ -161,20 +161,13 @@ d.contrast_estimates = d.beta_estimates(:,1)-d.beta_estimates(:,2);
 
 %Store tstat for comparison with real fMRI data
 model_fit = d.beta_estimates * d.detrended_design;
-d.residual = d.detrended_response - model_fit;
-d.std_error = std(d.residual,0,2)/sqrt(size(d.residual,2));
-d.tstat = d.contrast_estimates./d.std_error;
-
-% johan proposal (slightly over-general for this context)
+residual = d.detrended_response - model_fit;
 df = size(d.residual, 2) - rank(d.detrended_design');
 mrss = sum(d.residual.^2, 2) / df;
 cmat = inv(d.detrended_design * d.detrended_design');
 convec = [1 -1];
 se = sqrt(diag(convec * cmat * convec') * mrss);
-% about half the size of tstat_dplus_mean above
-t = d.contrast_estimates ./ se;
-% d.tstat = t;
-% / johan
+d.tstat = d.contrast_estimates ./ se;
 
 %Store BOLD responses for reference
 d.real_bold_response = d.face_response'-d.house_response';

--- a/create_glm.m
+++ b/create_glm.m
@@ -1,0 +1,54 @@
+function glm = create_glm(glm_var)
+glm.subrun_length = 2*glm_var.restdur+2*glm_var.blocks*(glm_var.blockdur+glm_var.restdur); 
+glm.hrf_distri = spm_hrf(glm_var.TR)';
+contexts = {'taskdplus', 'taskdminus'};
+for j=1:2 %2 design matrices for TaskD+ and TaskD-
+    % Construct GLM matrix 
+    subrun = cell(glm_var.n_subruns,1);
+    design_mat = cell(glm_var.n_subruns,1);
+    SVM_mat = cell(glm_var.n_subruns,1);
+    for k = 1:glm_var.n_subruns   
+        %randomize order of blocks within subruns (1 is faces, 2 is houses)
+        design = zeros(2,glm.subrun_length);
+        SVM_design = zeros(2*glm_var.blocks,glm.subrun_length);
+        subrun{k} = [repmat(1,1,glm_var.blocks),repmat(2,1,glm_var.blocks)];
+        subrun{k} = subrun{k}(randperm(length(subrun{k}))); 
+        %Structure is long_rest-subrun
+        %Define start times for each subrun and input into design matrix
+        sr1_start = glm_var.restdur+1;
+
+        cur_timepoint = sr1_start;
+        for i=1:length(subrun{k})
+            design(subrun{k}(i),cur_timepoint:cur_timepoint+glm_var.blockdur-1)=1;
+            cur_timepoint = cur_timepoint+glm_var.blockdur+glm_var.restdur;
+        end
+        %convolve with HRF to generate the design matrix
+        design_mat{k}=conv2(design,glm.hrf_distri);
+        % trim back to run length
+        design_mat{k} = design_mat{k}(:, 1:glm.subrun_length);
+        
+        %Generate individual columns for SVM classification
+        cur_timepoint = sr1_start;
+        c1_count = 1;
+        c2_count = 1;
+        for i=1:length(subrun{k})
+            if subrun{k}(i)==1
+                SVM_design(c1_count,cur_timepoint:cur_timepoint+glm_var.blockdur-1)=1;
+                c1_count = c1_count+1;
+            else
+                SVM_design(glm_var.blocks+c2_count,cur_timepoint:cur_timepoint+glm_var.blockdur-1)=1;
+                c2_count = c2_count+1;
+                
+            end
+            cur_timepoint = cur_timepoint+glm_var.blockdur+glm_var.restdur;
+        end
+        %convolve with HRF to generate the design matrix
+        SVM_mat{k} = conv2(SVM_design,glm.hrf_distri);
+        SVM_mat{k} = SVM_mat{k}(:,1:glm.subrun_length);
+    end
+    
+    glm.design(j).design_mat = design_mat;
+    glm.design(j).SVM_mat = SVM_mat;
+    % should not be implicit
+    glm.design(j).context = contexts{j};
+end

--- a/detrend_timecourses.m
+++ b/detrend_timecourses.m
@@ -1,0 +1,17 @@
+function detrended_data = detrend_timecourses(data)
+     detrended_data = cell(size(data,1),1);
+    for i=1:size(data,1)
+        % Linear, first order sinusoidal and mean detrending
+        nvols = size(data{i},2);
+        linear_trend=1:nvols;
+        sin_trend=sin((linear_trend)*2*pi/(nvols-1));
+        cos_trend=cos((linear_trend)*2*pi/(nvols-1));
+        mean_trend = ones(1,nvols);
+        dt_design = [linear_trend;sin_trend;cos_trend;mean_trend];
+
+        trend = data{i}/dt_design;
+        est = trend*dt_design;
+        detrended_data{i} = data{i} - est;
+    end
+end
+


### PR DESCRIPTION
* tstat calculation - propose alternate standard error formula
* fix error in conv2 - should not have had 'same' flag - that cuts the start AND end of the convolved design matrix to preserve the size of the original matrix. Not what we wanted. I apologise, I think this was my suggestion. I corrected to trim only the end.
* I refactored to break out the sub functions into independent m files, renamed some variables for clarity and to avoid conflicts with Matlab builtins, and cleaned up the code by avoiding unnecessary repetition, loops, transposes etc.